### PR TITLE
add defineAssignmentAssertion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ generator types {
   excludeCreateDto                = "false"
   excludeUpdateDto                = "false"
   excludeConnectDto               = "false"
+  definiteAssignmentAssertion     = "false"
 }
 ```
 
@@ -65,6 +66,7 @@ All parameters are optional.
 - [`classValidation`]: (default: `"false"`) - Add validation decorators from `class-validator`. Not compatible with `noDependencies = "true"` and `outputType = "interface"`.
 - [`noDependencies`]: (default: `"false"`) - Any imports and decorators that are specific to NestJS and Prisma are omitted, such that there are no references to external dependencies. This is useful if you want to generate appropriate DTOs for the frontend.
 - [`outputType`]: (default: `"class"`) - Output the DTOs as `class` or as `interface`. `interface` should only be used to generate DTOs for the frontend.
+- [`definiteAssignmentAssertion`]: (default: `"false"`) - Use definite assignment assertion operator (!) on optional fields. Enable this if you are using TypeScript's `strictPropertyInitialization` option.
 
 ## Annotations
 

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -38,6 +38,7 @@ interface RunParam {
   excludeUpdateDto: boolean;
   excludeConnectDto: boolean;
   prettierOptions?: Options;
+  definiteAssignmentAssertion: boolean;
 }
 
 export const run = ({
@@ -59,6 +60,7 @@ export const run = ({
     excludeUpdateDto,
     excludePlainDto,
     prettierOptions,
+    definiteAssignmentAssertion,
     ...preAndSuffixes
   } = options;
 
@@ -77,6 +79,7 @@ export const run = ({
     classValidation,
     outputType,
     noDependencies,
+    definiteAssignmentAssertion,
     ...preAndSuffixes,
   });
   const allModels = dmmf.datamodel.models;

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -94,6 +94,7 @@ interface MakeHelpersParam {
   classValidation: boolean;
   outputType: string;
   noDependencies: boolean;
+  definiteAssignmentAssertion: boolean;
 }
 export const makeHelpers = ({
   connectDtoPrefix,
@@ -107,6 +108,7 @@ export const makeHelpers = ({
   classValidation,
   outputType,
   noDependencies,
+  definiteAssignmentAssertion,
 }: MakeHelpersParam) => {
   const className = (name: string, prefix = '', suffix = '') =>
     `${prefix}${transformClassNameCase(name)}${suffix}`;
@@ -162,10 +164,13 @@ export const makeHelpers = ({
   ) =>
     `${decorateApiProperty(field)}${decorateClassValidators(field)}${
       field.name
-    }${unless(field.isRequired && !forceOptional, '?')}: ${fieldType(
-      field,
-      useInputTypes,
-    )};`;
+    }${
+      !field.isRequired || forceOptional
+        ? '?'
+        : definiteAssignmentAssertion
+        ? '!'
+        : ''
+    }: ${fieldType(field, useInputTypes)};`;
 
   const fieldsToDtoProps = (
     fields: ParsedField[],
@@ -179,10 +184,9 @@ export const makeHelpers = ({
     )}`;
 
   const fieldToEntityProp = (field: ParsedField) =>
-    `${decorateApiProperty(field)}${field.name}${unless(
-      field.isRequired,
-      '?',
-    )}: ${fieldType(field)} ${when(field.isNullable, ' | null')};`;
+    `${decorateApiProperty(field)}${field.name}${
+      !field.isRequired ? '?' : definiteAssignmentAssertion ? '!' : ''
+    }: ${fieldType(field)} ${when(field.isNullable, ' | null')};`;
 
   const fieldsToEntityProps = (fields: ParsedField[]) =>
     `${each(fields, (field) => fieldToEntityProp(field), '\n')}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,11 @@ export const generate = (options: GeneratorOptions) => {
     false,
   );
 
+  const definiteAssignmentAssertion = stringToBoolean(
+    options.generator.config.definiteAssignmentAssertion,
+    false,
+  );
+
   if (classValidation && outputType !== 'class') {
     throw new Error(
       `To use 'validation' validation decorators, 'outputType' must be 'class'.`,
@@ -155,6 +160,7 @@ export const generate = (options: GeneratorOptions) => {
     excludeUpdateDto,
     excludePlainDto,
     prettierOptions,
+    definiteAssignmentAssertion,
   });
 
   const indexCollections: Record<string, WriteableFileSpecs> = {};


### PR DESCRIPTION
Add `defineAssignmentAssertion` option to use definite assignment assertion operator (!) on optional fields. Need this if you are using TypeScript's `strictPropertyInitialization` option. See:
https://github.com/Microsoft/TypeScript-Vue-Starter/issues/36

This will generated something like:
```ts
export class User {
  id!: number
  createdAt!: Date
  updatedAt!: Date
  username!: string
  email!: string
  nickname?: string | null
}
```