### PR TITLE
feat: add prismaClientImport option to generator config

### DIFF
--- a/src/generator/compute-model-params/compute-create-dto-params.ts
+++ b/src/generator/compute-model-params/compute-create-dto-params.ts
@@ -147,7 +147,10 @@ export const computeCreateDtoParams = ({
     });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/compute-model-params/compute-entity-params.ts
+++ b/src/generator/compute-model-params/compute-entity-params.ts
@@ -133,7 +133,10 @@ export const computeEntityParams = ({
     imports.unshift({ from: '@nestjs/swagger', destruct });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/compute-model-params/compute-plain-dto-params.ts
+++ b/src/generator/compute-model-params/compute-plain-dto-params.ts
@@ -69,7 +69,10 @@ export const computePlainDtoParams = ({
     imports.unshift({ from: '@nestjs/swagger', destruct });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/compute-model-params/compute-update-dto-params.ts
+++ b/src/generator/compute-model-params/compute-update-dto-params.ts
@@ -132,7 +132,10 @@ export const computeUpdateDtoParams = ({
     });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -42,6 +42,7 @@ export function concatUniqueIntoArray<T = any>(
 
 export const makeImportsFromPrismaClient = (
   fields: ParsedField[],
+  t: TemplateHelpers,
 ): ImportStatementParams | null => {
   const enumsToImport = uniq(
     fields.filter(({ kind }) => kind === 'enum').map(({ type }) => type),
@@ -55,7 +56,7 @@ export const makeImportsFromPrismaClient = (
   }
 
   return {
-    from: '@prisma/client',
+    from: t.config.prismaClientImport,
     destruct: importPrisma ? ['Prisma', ...enumsToImport] : enumsToImport,
   };
 };

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -31,6 +31,7 @@ interface RunParam {
   fileNamingStyle: NamingStyle;
   classValidation: boolean;
   outputType: string;
+  prismaClientImport: string;
   noDependencies: boolean;
   excludeEntity: boolean;
   excludePlainDto: boolean;
@@ -53,6 +54,7 @@ export const run = ({
     fileNamingStyle = 'camel',
     classValidation,
     outputType,
+    prismaClientImport,
     noDependencies,
     excludeConnectDto,
     excludeCreateDto,
@@ -79,6 +81,7 @@ export const run = ({
     classValidation,
     outputType,
     noDependencies,
+    prismaClientImport,
     definiteAssignmentAssertion,
     ...preAndSuffixes,
   });

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -89,6 +89,7 @@ interface MakeHelpersParam {
   dtoSuffix: string;
   entityPrefix: string;
   entitySuffix: string;
+  prismaClientImport: string;
   transformClassNameCase?: (item: string) => string;
   transformFileNameCase?: (item: string) => string;
   classValidation: boolean;
@@ -103,6 +104,7 @@ export const makeHelpers = ({
   dtoSuffix,
   entityPrefix,
   entitySuffix,
+  prismaClientImport,
   transformClassNameCase = echo,
   transformFileNameCase = echo,
   classValidation,
@@ -202,6 +204,7 @@ export const makeHelpers = ({
       dtoSuffix,
       entityPrefix,
       entitySuffix,
+      prismaClientImport,
       classValidation,
       outputType,
       noDependencies,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export const generate = (options: GeneratorOptions) => {
     dtoSuffix = 'Dto',
     entityPrefix = '',
     entitySuffix = '',
+    prismaClientImport = '@prisma/client',
     fileNamingStyle = 'camel',
     outputType = 'class',
   } = options.generator.config;
@@ -153,6 +154,7 @@ export const generate = (options: GeneratorOptions) => {
     fileNamingStyle,
     classValidation,
     outputType,
+    prismaClientImport,
     noDependencies,
     excludeConnectDto,
     excludeCreateDto,


### PR DESCRIPTION
# Why?
`prisma-types-generator` works fine by default when generating the prisma types from within your node application.

The `@prisma/client` **import** statements will break if you  are exporting the generated prisma type from another node application and importing them as a NPM package.

## Problem
1. I have a **@app** and **@db**
2. I generate the client with `prisma generate` in the **@db** dist folder to export it.
3. If I use the standard `@prisma/client` import, it does not find it since the client is now generated in a non-standard location.

## Solution
I created a `prismaClientImport` optional string option to specify a different client location. If unspecified, the string defaults to `@prisma/client`

# How to use
Use the `prismaClientImport` option to specify a different path for your Prisma client

```
generator types {
  output                          = "../types"
  prismaClientImport              = "../../dist/index.js"
  provider                        = "prisma-types-generator"
}
```