### PR TITLE
feat: connect enum imports

### DIFF
--- a/src/generator/compute-model-params/compute-create-dto-params.ts
+++ b/src/generator/compute-model-params/compute-create-dto-params.ts
@@ -147,7 +147,10 @@ export const computeCreateDtoParams = ({
     });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/compute-model-params/compute-entity-params.ts
+++ b/src/generator/compute-model-params/compute-entity-params.ts
@@ -133,7 +133,10 @@ export const computeEntityParams = ({
     imports.unshift({ from: '@nestjs/swagger', destruct });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/compute-model-params/compute-plain-dto-params.ts
+++ b/src/generator/compute-model-params/compute-plain-dto-params.ts
@@ -69,7 +69,10 @@ export const computePlainDtoParams = ({
     imports.unshift({ from: '@nestjs/swagger', destruct });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/compute-model-params/compute-update-dto-params.ts
+++ b/src/generator/compute-model-params/compute-update-dto-params.ts
@@ -132,7 +132,10 @@ export const computeUpdateDtoParams = ({
     });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers,
+  );
   if (importPrismaClient) imports.unshift(importPrismaClient);
 
   return {

--- a/src/generator/compute-model-params/index.ts
+++ b/src/generator/compute-model-params/index.ts
@@ -18,7 +18,7 @@ export const computeModelParams = ({
   templateHelpers,
 }: ComputeModelParamsParam): ModelParams => ({
   // TODO find out if model needs `ConnectDTO`
-  connect: computeConnectDtoParams({ model }),
+  connect: computeConnectDtoParams({ model, templateHelpers }),
   create: computeCreateDtoParams({
     model,
     allModels, // ? should this be `allModels: models` instead

--- a/src/generator/generate-connect-dto.ts
+++ b/src/generator/generate-connect-dto.ts
@@ -7,13 +7,11 @@ interface GenerateConnectDtoParam extends ConnectDtoParams {
 export const generateConnectDto = ({
   model,
   fields,
+  imports,
   templateHelpers: t,
-}: GenerateConnectDtoParam) => {
-  const template = `
+}: GenerateConnectDtoParam) => `
+  ${t.importStatements(imports)}
   export ${t.config.outputType} ${t.connectDtoName(model.name)} {
     ${t.fieldsToDtoProps(fields, true, false)}
   }
-  `;
-
-  return template;
-};
+`;

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -42,6 +42,7 @@ export function concatUniqueIntoArray<T = any>(
 
 export const makeImportsFromPrismaClient = (
   fields: ParsedField[],
+  t: TemplateHelpers,
 ): ImportStatementParams | null => {
   const enumsToImport = uniq(
     fields.filter(({ kind }) => kind === 'enum').map(({ type }) => type),
@@ -55,7 +56,7 @@ export const makeImportsFromPrismaClient = (
   }
 
   return {
-    from: '@prisma/client',
+    from: t.config.prismaClientImport,
     destruct: importPrisma ? ['Prisma', ...enumsToImport] : enumsToImport,
   };
 };

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -31,6 +31,7 @@ interface RunParam {
   fileNamingStyle: NamingStyle;
   classValidation: boolean;
   outputType: string;
+  prismaClientImport: string;
   noDependencies: boolean;
   excludeEntity: boolean;
   excludePlainDto: boolean;
@@ -53,6 +54,7 @@ export const run = ({
     fileNamingStyle = 'camel',
     classValidation,
     outputType,
+    prismaClientImport,
     noDependencies,
     excludeConnectDto,
     excludeCreateDto,
@@ -79,6 +81,7 @@ export const run = ({
     classValidation,
     outputType,
     noDependencies,
+    prismaClientImport,
     definiteAssignmentAssertion,
     ...preAndSuffixes,
   });

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -89,6 +89,7 @@ interface MakeHelpersParam {
   dtoSuffix: string;
   entityPrefix: string;
   entitySuffix: string;
+  prismaClientImport: string;
   transformClassNameCase?: (item: string) => string;
   transformFileNameCase?: (item: string) => string;
   classValidation: boolean;
@@ -103,6 +104,7 @@ export const makeHelpers = ({
   dtoSuffix,
   entityPrefix,
   entitySuffix,
+  prismaClientImport,
   transformClassNameCase = echo,
   transformFileNameCase = echo,
   classValidation,
@@ -202,6 +204,7 @@ export const makeHelpers = ({
       dtoSuffix,
       entityPrefix,
       entitySuffix,
+      prismaClientImport,
       classValidation,
       outputType,
       noDependencies,

--- a/src/generator/types.ts
+++ b/src/generator/types.ts
@@ -56,7 +56,7 @@ export interface DtoParams {
   imports: ImportStatementParams[];
 }
 
-export type ConnectDtoParams = Omit<DtoParams, 'imports'>;
+export type ConnectDtoParams = DtoParams;
 
 export interface CreateDtoParams extends DtoParams {
   extraClasses: string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export const generate = (options: GeneratorOptions) => {
     dtoSuffix = 'Dto',
     entityPrefix = '',
     entitySuffix = '',
+    prismaClientImport = '@prisma/client',
     fileNamingStyle = 'camel',
     outputType = 'class',
   } = options.generator.config;
@@ -153,6 +154,7 @@ export const generate = (options: GeneratorOptions) => {
     fileNamingStyle,
     classValidation,
     outputType,
+    prismaClientImport,
     noDependencies,
     excludeConnectDto,
     excludeCreateDto,


### PR DESCRIPTION
⚠️ Merge **AFTER** #5 since those changes are included in this PR. I needed the second argument in the `makeImportsFromPrismaClient` function. Sorry 🙇 ⚠️

# Why

## Problem
I have a case where I use an enum as a unique identifier in my database. It is very unusual but this for defining roles.
The generator does not generate **import** statements when using enums in Connect DTOs.

## Solution
I modified the code to generate `import` statements for enums in Connect DTOs.

# How to use
Nothing to do, just generate as usual

⚠️ Merge **AFTER** #5 since those changes are included in this PR. Sorry 🙇 ⚠️