### PR TITLE
feat: add js extension for Node module compatibility

### DIFF
--- a/src/generator/compute-model-params/compute-entity-params.ts
+++ b/src/generator/compute-model-params/compute-entity-params.ts
@@ -73,7 +73,7 @@ export const computeEntityParams = ({
           `${getRelativePath(
             model.output.entity,
             modelToImportFrom.output.entity,
-          )}${path.sep}${templateHelpers.entityFilename(field.type)}`,
+          )}${path.sep}${templateHelpers.entityFilename(field.type)}.js`,
         );
 
         // don't double-import the same thing

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -198,7 +198,7 @@ export const generateRelationInput = ({
       from: slash(
         `${getRelativePath(model.output.dto, modelToImportFrom.output.dto)}${
           path.sep
-        }${t.createDtoFilename(field.type)}`,
+        }${t.createDtoFilename(field.type)}.js`,
       ),
       destruct: [preAndPostfixedName],
     });
@@ -223,7 +223,7 @@ export const generateRelationInput = ({
       from: slash(
         `${getRelativePath(model.output.dto, modelToImportFrom.output.dto)}${
           path.sep
-        }${t.connectDtoFilename(field.type)}`,
+        }${t.connectDtoFilename(field.type)}.js`,
       ),
       destruct: [preAndPostfixedName],
     });
@@ -283,7 +283,7 @@ export const mergeImportStatements = (
 
   if (first.default && second.default) {
     throw new Error(
-      `Can not merge import statements; both statements have set the 'default' preoperty`,
+      `Can not merge import statements; both statements have set the 'default' property`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export const generate = (options: GeneratorOptions) => {
         fileName: fileSpec?.fileName || path.join(dirName, 'index.ts'),
         content: [
           fileSpec?.content || '',
-          `export * from './${path.basename(fileName, '.ts')}';`,
+          `export * from './${path.basename(fileName, '.ts')}.js';`,
         ].join('\n'),
       };
     });


### PR DESCRIPTION
# Why

## Problem
If I use `NodeNext` as a module resolution in the `tsconfig.json`, I get compiler errors since `NodeNext` requires the `js` extension when importing a relative module.

## Solution
I modified the code to use `.js` for all relative imports. It should not affect previous users since using the `js` extension is valid in CommonJS and ESM modules. See this [article](https://www.typescriptlang.org/docs/handbook/esm-node.html#type-in-packagejson-and-new-extensions) in the TS handbook.

# How to use
Nothing to do for the user.