### PR TITLE
feat: remove IsRFC3339 class-validator if we specify IsDate

### DIFF
--- a/src/generator/class-validator.ts
+++ b/src/generator/class-validator.ts
@@ -156,6 +156,15 @@ export function parseClassValidators(field: DMMF.Field): IClassValidator[] {
       if (validator) {
         validators.push(validator);
       }
+      // INFO: If we want a real Date object, i.e. because of implicitConversion: true for query parameters, we remove the IsRFC3339 which checks that it is a formatted Date string
+      if (validator?.name === 'IsDate') {
+        const rfcIndex = validators.findIndex(
+          (validator) => validator.name === 'IsRFC3339',
+        );
+        if (rfcIndex > -1) {
+          validators.splice(rfcIndex, 1);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# Why

## Problem
We had to activate `transformOptions: { enableImplicitConversion: true },` in our validation pipe because we use complex objects in query parameters. Since everything is a **string** in query parameters in NestJS, the objects would fail validation. But `date-time` formatted strings were implicitly cast as `Date` objects and would fail the `@IsRFC3339` string validation. 

After adding a `@IsDate` validator, I realised the validation still failed as the old `@IsRFC3339` validator from the scalar Prisma type was still there.

## Solution
This simply looks if you want a real Date object with the `@IsDate` validator, and, if yes, removes the `@IsRFC3339` validator if there is one.

# How to use
Nothing to do, just generate as usual